### PR TITLE
python port of call-and-bridge with test suite

### DIFF
--- a/lambdas/call-and-bridge/package.json
+++ b/lambdas/call-and-bridge/package.json
@@ -16,12 +16,14 @@
     "lambda": "scripts/lambda",
     "active": "scripts/active",
     "swap": "scripts/swap && scripts/active",
+    "swap:py": "scripts/swap-py && scripts/active",
     "status": "scripts/status",
     "versions": "scripts/versions",
     "invoke": "scripts/invoke",
     "logs": "scripts/logs"
   },
   "devDependencies": {
+    "@aws-cdk/aws-lambda-python-alpha": "^2.23.0-alpha.0",
     "@types/jest": "^27.4.1",
     "@types/node": "10.17.27",
     "aws-cdk": "2.12.0",

--- a/lambdas/call-and-bridge/scripts/active
+++ b/lambdas/call-and-bridge/scripts/active
@@ -5,14 +5,19 @@ ACTIVE=$(aws chime get-sip-media-application --sip-media-application-id  $SMA_ID
 
 PARENT=$(jq -r .[].smaHandlerArn $BASEDIR/cdk-outputs.json) 
 LOCAL=$(jq -r .[].smaHandlerArn ./cdk-outputs.json) 
+LOCAL_PY=$(jq -r '.[].pyHandlerArn' ./cdk-outputs.json) 
 DONE="There is an error, please check the lambda associations"
 
 P="PARENT is active:    $PARENT"
 L="LOCAL is active:     $LOCAL"
+PY="  *PYTHON* version"
 
 if [ $ACTIVE == $PARENT ]; then
   echo $P
-fi
-if [ $ACTIVE == $LOCAL ]; then
+elif [ $ACTIVE == $LOCAL ]; then
   echo $L
+elif [ $ACTIVE == $LOCAL_PY ]; then
+  echo $L; echo $PY
+else
+  echo $DONE
 fi

--- a/lambdas/call-and-bridge/scripts/clean
+++ b/lambdas/call-and-bridge/scripts/clean
@@ -7,4 +7,14 @@ rm -Rf package-lock.json yarn.lock
 rm -Rf src/*~ lib/*~ test/*~ userdata/*~ scripts/*~ configs/*~
 echo "removing node_modules, this takes a moment..."
 rm -Rf node_modules
+# remove testing cruft
+rm -f src/*.d.ts src/*.js
+rm -Rf src/coverage
+rm -Rf src/htmlcov
+rm -Rf src/node_modules
+mv src/test/lambda-runner.js src/test/lambda-runner.js.save
+rm src/test/*.d.ts src/test/*.js
+mv src/test/lambda-runner.js.save src/test/lambda-runner.js
+rm -Rf src/test/cases/**/*-event*.json
+rm -Rf src/test/cases/**/*-out*.json
 echo "all done!"

--- a/lambdas/call-and-bridge/scripts/swap-py
+++ b/lambdas/call-and-bridge/scripts/swap-py
@@ -1,0 +1,23 @@
+#!/bin/bash
+BASEDIR=../..
+SMA_ID=$(jq -r '.[].smaId' $BASEDIR/cdk-outputs.json)  # parent CDK folder
+ACTIVE=$(aws chime get-sip-media-application --sip-media-application-id  $SMA_ID | jq -r '.[].Endpoints[0].LambdaArn')
+echo "Active lambda is: $ACTIVE"
+
+PARENT=$(jq -r '.[].smaHandlerArn' $BASEDIR/cdk-outputs.json) 
+LOCAL=$(jq -r '.[].pyHandlerArn' ./cdk-outputs.json) 
+DONE="There is an error, please check the lambda associations"
+
+echo "PARENT lambda:    $PARENT"
+echo "LOCAL lambda:     $LOCAL"
+
+if [ $ACTIVE == $LOCAL ]; then
+  ENDPOINTS="[{\"LambdaArn\": \"$PARENT\"}]"
+  DONE="updating SMA $SMA_ID to use lambda $PARENT"
+  aws chime update-sip-media-application  --sip-media-application-id $SMA_ID --endpoints "$ENDPOINTS"
+else
+  ENDPOINTS="[{\"LambdaArn\": \"$LOCAL\"}]"
+  DONE="updating SMA $SMA_ID to use lambda $LOCAL"
+  aws chime update-sip-media-application  --sip-media-application-id $SMA_ID --endpoints "$ENDPOINTS"
+  echo $DONE
+fi

--- a/lambdas/call-and-bridge/src/.vscode/settings.json
+++ b/lambdas/call-and-bridge/src/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "python.linting.pycodestyleEnabled": true,
+    "python.linting.enabled": true
+}

--- a/lambdas/call-and-bridge/src/index.py
+++ b/lambdas/call-and-bridge/src/index.py
@@ -1,0 +1,251 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from copy import deepcopy
+import json
+import logging
+import os
+
+
+# Set LogLevel using environment variable, fallback to INFO if not present
+logger = logging.getLogger()
+log_level = os.getenv('LogLevel', 'INFO')
+if log_level not in ['INFO', 'DEBUG']:
+    log_level = 'INFO'
+logger.setLevel(log_level)
+log_prefix = ''
+
+
+#
+# statics
+#
+wav_file_bucket = os.getenv('WAVFILE_BUCKET', None)
+
+
+# To read more on customizing the Pause action, see https://docs.aws.amazon.com/chime/latest/dg/pause.html
+def pause_action(call_id=None):
+    a = {
+        'Type': 'Pause',
+        'Parameters': {
+                # 'CallId': call_id,
+                'DurationInMilliseconds': '3000'
+        }
+    }
+    if call_id is not None:
+        a['Parameters']['CallId'] = call_id
+
+    return a
+
+
+def speak_and_get_digits_action(call_id, regex, speak_text):
+    return {
+        'Type': 'SpeakAndGetDigits',
+        'Parameters': {
+            'CallId': call_id,
+            'InputDigitsRegex': regex,
+            'SpeechParameters': {
+                'Text': speak_text,
+                'Engine': "neural",
+                'LanguageCode': "en-US",
+                'TextType': "ssml",
+                'VoiceId': "Joanna"
+            },
+            'FailureSpeechParameters': {
+                'Text': "<speak>Ooops, there was an error.</speak>",
+                'Engine': "neural",
+                'LanguageCode': "en-US",
+                'TextType': "ssml",
+                'VoiceId': "Joanna"
+            },
+            'MinNumberOfDigits': 11,
+            'MaxNumberOfDigits': 11,
+            'TerminatorDigits': ['#'],
+            'InBetweenDigitsDurationInMilliseconds': 5000,
+            'Repeat': 3,
+            'RepeatDurationInMilliseconds': 10000
+        }
+    }
+
+
+# To read more on customizing the VoiceFocus action, see https://docs.aws.amazon.com/chime/latest/dg/voicefocus.html
+def voicefocus_action(call_id, enabled=True):
+    return {
+        'Type': 'VoiceFocus',
+        "Parameters": {
+                'Enable': enabled,
+                'CallId': call_id,
+        }
+    }
+
+
+# To read more on customizing the ReceiveDigits action, see https://docs.aws.amazon.com/chime/latest/dg/listen-to-digits.html
+def receive_digits_action(call_id):
+    return {
+        'Type': 'ReceiveDigits',
+        'Parameters': {
+                'CallId': call_id,
+                'InputDigitsRegex': '[0-1]$',
+                'InBetweenDigitsDurationInMilliseconds': 1000,
+                'FlushDigitsDurationInMilliseconds': 10000
+        }
+    }
+
+
+# To read more on customizing the CallAndBridge action, see https://docs.aws.amazon.com/chime/latest/dg/call-and-bridge.html
+def call_and_bridge_action(caller_id, destination):
+    return {
+        'Type': 'CallAndBridge',
+        'Parameters': {
+            'CallTimeoutSeconds': 30,
+            'CallerIdNumber': caller_id,
+            'RingbackTone': {
+                'Type': "S3",
+                'BucketName': wav_file_bucket,
+                'Key': "ringback.wav"
+            },
+            'Endpoints':
+            [
+                {
+                    'Uri': destination,
+                    'BridgeEndpointType': 'PSTN'
+                }
+            ]
+        }
+    }
+
+
+# A wrapper for all responses back to the service
+def response(*actions):
+    return {
+        'SchemaVersion': '1.0',
+        'Actions': [*actions]
+    }
+
+#
+# handlers
+#
+
+
+# For new incoming calls, speak a greeting and collect digits of destination number.
+# Regex for digits entered allows US calling, except for premium rate numbers
+def new_call_handler(e):
+    call_id = e['CallDetails']['Participants'][0]['CallId']
+
+    logger.info('SEND {} {}'.format(
+        log_prefix, 'Sending PlayAndGetDigits action to get Destination Number'))
+
+    return response(
+        pause_action(call_id),
+        speak_and_get_digits_action(
+            call_id,
+            "^[1][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]",
+            "<speak>Hello!  Please enter the number you would like to call, starting with a one followed by ten digits</speak>"
+        ))
+
+
+def place_call(e):
+    call_id = e['CallDetails']['Participants'][0]['CallId']
+    from_number = e['CallDetails']['Participants'][0]['From']
+    received_digits = f"+{e['ActionData']['ReceivedDigits']}"
+
+    return [
+        pause_action(call_id),
+        call_and_bridge_action(from_number, received_digits)
+    ]
+
+
+def connect_call(e):
+    caller = list(filter(lambda p: p['Direction'] ==
+                  "Inbound", e['CallDetails']['Participants']))[0]
+    recipient = list(filter(
+        lambda p: p['Direction'] == "Outbound", e['CallDetails']['Participants']))[0]
+
+    return [voicefocus_action(caller['CallId'], False),
+            voicefocus_action(recipient['CallId'], False),
+            receive_digits_action(caller['CallId'])
+            ]
+
+
+# If we receive an ACTION_SUCCESSFUL event we can take further actions,
+# or default to responding with a NoOp (empty set of actions)
+action_handlers = {
+    'SpeakAndGetDigits': place_call,
+    'CallAndBridge': connect_call,
+    # 'ReceiveDigits': _,
+    # 'VoiceFocus': _
+}
+def action_succesful_handler(e):
+    actions = []
+
+    try:
+        actions = action_handlers[e['ActionData']['Type']](e)
+    except KeyError:
+        pass
+    except Exception as err:
+        logger.warn(f"exception in action handler {err}")
+
+    return response(*actions)
+
+
+def digits_recevied_handler(e):
+    actions = []
+
+    try:
+        if (e['ActionData']['Type'] != 'ReceivedDigits'):
+            raise Exception()
+
+        caller = list(filter(
+            lambda p: p['Direction'] == "Inbound", e['CallDetails']['Participants']))[0]
+        recipient = list(filter(
+            lambda p: p['Direction'] == "Outbound", e['CallDetails']['Participants']))[0]
+
+        disable = e['ActionData']['ReceivedDigits'] == "0"
+        enable = e['ActionData']['ReceivedDigits'] == "1"
+
+        if not(disable ^ enable):
+            raise Exception()
+
+        actions = [
+            voicefocus_action(caller, (enable and not disable)),
+            voicefocus_action(recipient, (enable and not disable)),
+            receive_digits_action(caller)
+        ]
+
+    except Exception as err:
+        logger.warn(f"Exception in digits received {err}")
+
+    return response(*actions)
+
+
+# message - handler mapping table
+event_handlers = {
+    'NEW_INBOUND_CALL': new_call_handler,
+    'ACTION_SUCCESSFUL': action_succesful_handler,
+    'DIGITS_RECEIVED': digits_recevied_handler,
+    # 'HANGUP': response()
+}
+def handler(event, context):
+    logger.info(f"called with {json.dumps(event, indent=2)}")
+
+    resp = response()
+    try:
+        resp = event_handlers[event['InvocationEventType']](event)
+    except Exception as e:
+        logger.info(f"exception in handler: {e}")
+
+    logger.info(f"returning {json.dumps(resp, indent=2)}")
+    return resp

--- a/lambdas/call-and-bridge/src/package.json
+++ b/lambdas/call-and-bridge/src/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "test": "jest --coverage",
-    "test:watch": "jest --watch --coverage"
+    "test:watch": "jest --watch --coverage",
+    "test:py": "python3 -m unittest -v test/call_and_bridge_test.py"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/lambdas/call-and-bridge/src/requirements.txt
+++ b/lambdas/call-and-bridge/src/requirements.txt
@@ -1,0 +1,15 @@
+attrs==21.4.0
+boto3==1.22.9
+botocore==1.25.9
+coverage==6.3.2
+importlib-resources==5.7.1
+jmespath==1.0.0
+jsonschema==4.4.0
+marshmallow==3.15.0
+packaging==21.3
+pyparsing==3.0.8
+pyrsistent==0.18.1
+python-dateutil==2.8.2
+s3transfer==0.5.2
+urllib3==1.26.9
+zipp==3.8.0

--- a/lambdas/call-and-bridge/src/test/call_and_bridge_test.py
+++ b/lambdas/call-and-bridge/src/test/call_and_bridge_test.py
@@ -66,7 +66,7 @@ class Test_Call_And_Bridge(unittest.TestCase):
             validate(instance=d, schema=s)
             self.assertTrue(True)
         except Exception as e:
-            self.assertTrue(False, e.message)
+            self.assertTrue(False, e)
 
     def check_schema_10(self, d):
         self.check_validate(d, self.basic_schema)
@@ -191,6 +191,15 @@ class Test_Call_And_Bridge(unittest.TestCase):
 
         import index
         self.assertIsNone(index.wav_file_bucket)
+
+    def test_log_level_set_from_env_var(self):
+        import index
+        self.assertEqual(index.log_level, 'INFO')
+
+        self.tearDown()
+        os.environ['LogLevel'] = 'DEBUG'
+        import index
+        self.assertEqual(index.log_level, 'DEBUG')
 
     def test_new_inbound_call(self):
         event = deepcopy(self.test_event)

--- a/lambdas/call-and-bridge/src/test/call_and_bridge_test.py
+++ b/lambdas/call-and-bridge/src/test/call_and_bridge_test.py
@@ -1,0 +1,301 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from array import array
+from ast import expr_context
+from cmath import exp
+from copy import deepcopy
+import json
+from jsonschema import validate
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+import boto3
+
+
+class Test_Call_And_Bridge(unittest.TestCase):
+    bucket_env_var = "WAVFILE_BUCKET"
+    fake_bucket_name = "fake-bucket"
+
+    def __init__(self, methodName: str = ...) -> None:
+        super().__init__(methodName)
+
+        with open("../../../events/inbound.json") as f:
+            self.test_event = json.load(f)
+
+        with open("./test/cases/basic/basic-schema.json") as f:
+            self.basic_schema = json.load(f)
+
+        with open("./test/cases/new-call/new-call-schema.json") as f:
+            self.new_call_schema = json.load(f)
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        # set env vars
+        os.environ[Test_Call_And_Bridge.bucket_env_var] = Test_Call_And_Bridge.fake_bucket_name
+
+    def tearDown(self) -> None:
+        # force an import the target function each and every time
+        if 'index' in sys.modules:
+            del sys.modules["index"]
+
+        # reset env vars
+        os.environ.pop(Test_Call_And_Bridge.bucket_env_var, None)
+
+        super().tearDown()
+
+    def check_validate(self, d, s):
+        try:
+            validate(instance=d, schema=s)
+            self.assertTrue(True)
+        except Exception as e:
+            self.assertTrue(False, e.message)
+
+    def check_schema_10(self, d):
+        self.check_validate(d, self.basic_schema)
+
+    def check_new_call_schema(self, d):
+        self.check_validate(d, self.new_call_schema)
+
+    def check_empty_actions(self, d):
+        try:
+            self.assertEqual(len(d['Actions']), 0)
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_pause(self, d, count=1):
+        rp = list(filter(lambda a: a['Type'] == 'Pause', d['Actions']))
+        self.assertEqual(len(rp), count)
+        try:
+            [self.assertIsNotNone(
+                r['Parameters']['DurationInMilliseconds']) for r in rp]
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_pause2(self, d):
+        self.check_pause(d, count=2)
+
+    def check_speak_collect_digits(self, d) -> None:
+        rp = list(filter(lambda a: a['Type'] ==
+                  'SpeakAndGetDigits', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['CallId'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['SpeechParameters']['Text'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['FailureSpeechParameters']['Text'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_call_and_bridge(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'CallAndBridge', d['Actions']))
+        self.assertEqual(len(rp), 1)
+
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['CallerIdNumber'])
+
+            for e in rp[0]['Parameters']['Endpoints']:
+                self.assertIsNotNone(e['Uri'])
+                self.assertIsNotNone(e['BridgeEndpointType'])
+
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_voice_focus(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'VoiceFocus', d['Actions']))
+        self.assertGreaterEqual(len(rp), 1)
+
+        try:
+            for v in rp:
+                self.assertIsNotNone(v['Parameters']['Enable'])
+                self.assertIsNotNone(v['Parameters']['CallId'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_receive_digits(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'ReceiveDigits', d['Actions']))
+        self.assertEqual(len(rp), 1)
+
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['InputDigitsRegex'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_play(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'PlayAudio', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['AudioSource'])
+        except Exception as e:
+            self.assertTrue(False, e.message)
+
+    def check_hangup(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'Hangup', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertEqual(rp[0]['Parameters']['SipResponseCode'], '0')
+        except Exception as e:
+            self.assertTrue(False, e.message)
+
+    def call_and_test(self, event, tests: array):
+        # since the static setup is tested separately, need to reload
+        from index import handler
+
+        r = handler(event, None)
+        [t(r) for t in tests]
+
+    def copy_caller_to_recipient(self, event):
+        participant = deepcopy(event['CallDetails']['Participants'][0])
+        participant['Direction'] = "Outbound"
+        event['CallDetails']['Participants'].append(participant)
+
+    #
+    # Tests
+    #
+
+    def test_empty(self):
+        event = {}
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_wav_file_bucket_env_var(self):
+        # unset any env var for the bucket
+        import index
+        # .setUp() sets an env var
+        self.assertEqual(index.wav_file_bucket,
+                         Test_Call_And_Bridge.fake_bucket_name)
+
+        # reset it all...
+        self.tearDown()
+        self.assertIsNone(os.getenv(Test_Call_And_Bridge.bucket_env_var, None))
+
+        import index
+        self.assertIsNone(index.wav_file_bucket)
+
+    def test_new_inbound_call(self):
+        event = deepcopy(self.test_event)
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_new_call_schema,
+                            self.check_pause,
+                            self.check_speak_collect_digits
+                            ])
+
+    def test_action_successful_speak_get_digits(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['ActionData'] = {'Type': 'SpeakAndGetDigits',
+                               'ReceivedDigits': "12125551212"}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_pause,
+                            self.check_call_and_bridge
+                            ])
+
+    def test_action_successful_call_and_bridge(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['ActionData'] = {'Type': 'CallAndBridge'}
+        # clone and munge participant[0] --> [1]
+        self.copy_caller_to_recipient(event)
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_voice_focus,
+                            self.check_receive_digits
+                            ])
+
+    def test_action_successful_digits_received(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['ActionData'] = {'Type': 'ReceiveDigits'}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_empty_actions
+                            ])
+
+    def test_action_successful_voice_focus(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['ActionData'] = {
+            'Type': 'VoiceFocus',
+            'Parameters': {
+                'Enable': True
+            }
+        }
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_empty_actions
+                            ])
+
+    def test_action_successful_bad_selector(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['ActionData'] = {'Type': 'foobar'}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_empty_actions
+                            ])
+
+    def go_digits_received(self, digit, tests: array):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "DIGITS_RECEIVED"
+        event['ActionData'] = {
+            'Type': 'ReceivedDigits', 'ReceivedDigits': digit}
+
+        self.copy_caller_to_recipient(event)
+
+        self.call_and_test(event, tests)
+
+    def test_digits_received_0(self):
+        self.go_digits_received(
+            "0", [self.check_schema_10, self.check_voice_focus, self.check_receive_digits])
+
+    def test_digits_received_1(self):
+        self.go_digits_received(
+            "1", [self.check_schema_10, self.check_voice_focus, self.check_receive_digits])
+
+    def test_digits_received_N(self):
+        self.go_digits_received("7", [self.check_schema_10])
+
+    def test_digits_received_no_action(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "DIGITS_RECEIVED"
+        event['ActionData'] = {'Type': 'no action'}
+
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_hangup(self):
+        # TODO
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "HANGUP"
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_bad_action(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "IMBAAD"
+        self.call_and_test(event, [self.check_schema_10])

--- a/lambdas/call-and-bridge/src/test/cases/basic/basic-schema.json
+++ b/lambdas/call-and-bridge/src/test/cases/basic/basic-schema.json
@@ -1,0 +1,12 @@
+{
+    "required": [
+          "SchemaVersion",
+          "Actions"
+      ],
+  "properties": {
+          "SchemaVersion": {
+              "type": "string",
+              "const": "1.0"
+          }
+      }
+  }

--- a/lambdas/call-and-bridge/src/test/cases/basic/basic.bash
+++ b/lambdas/call-and-bridge/src/test/cases/basic/basic.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# 
+
+echo ""; echo "Testing Client Construction"; echo ""; echo ""
+
+# TS validates as part of every call
+pushd ../../..
+single_client_py=$(python3 -m unittest -v -k test_static_client  test/lambda_function_test.py >/dev/null && echo true || echo false)
+popd
+
+single_client_valid=$($single_client_py)
+
+
+echo ""; echo "Testing Blank Input"; echo ""; echo ""
+
+rm -f blank-event.json
+echo "{}" >>blank-event.json
+rm -f basic-out.json
+# node runner
+node ../../lambda-runner.js ./cases/basic/blank-event.json basic-out-ts.json >/dev/null 
+# python runner
+python3 ../../lambda-runner.py blank-event.json basic-out-py.json
+
+blank_valid_ts=$(ajv validate -s basic-schema.json -d basic-out-ts.json >/dev/null && echo true || echo false)
+blank_valid_py=$(ajv validate -s basic-schema.json -d basic-out-py.json >/dev/null && echo true || echo false)
+
+blank_valid=$($blank_valid_ts && $blank_valid_py)
+
+# copy and munge inbound event
+
+# success
+echo ""; echo "Testing ACTION_SUCCESSFUL Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "ACTION_SUCCESSFUL"' >>basic-event.json
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+success_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+success_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+success_valid=$($success_valid_ts && $success_valid_py)
+
+# hangup
+#
+#   need to force a no-err return from the sender, which needs a mock, use Jest
+echo ""; echo "Testing HANGUP Input"; echo ""; echo ""
+
+rm -f basic-out.out
+pushd ../../..
+hangup_valid_ts=$(yarn test -t 'first hangup' >/dev/null && echo true || echo false)
+hangup_valid_py=$(python3 -m unittest -v -k test_hangup_action  test/lambda_function_test.py >/dev/null && echo true || echo false)
+popd
+
+hangup_valid=$($hangup_valid_ts && $hangup_valid_py)
+
+# hangup -- force error
+#
+#   no way to inject/mock the client behavior from bash... so call jest
+echo ""; echo "Testing FORCED ERROR on HANGUP Input"; echo ""; echo ""
+
+rm -f forced-error.out
+pushd ../../..
+force_valid_ts=$(yarn test -t 'force hangup error' >/dev/null && echo true || echo false)
+force_valid_py=$(python3 -m unittest -v -k test_forced_exception  test/lambda_function_test.py >/dev/null && echo true || echo false)
+popd
+
+force_valid=$($force_valid_ts && $force_valid_py)
+
+# second hangup
+echo ""; echo "Testing _second_ HANGUP Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "HANGUP"' >>basic-event.json
+mv basic-event.json basic-event-tmp.json
+cat basic-event-tmp.json | jq '.CallDetails.Participants[0].Direction = "foobar"' >>basic-event.json
+
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+hangup2_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+hangup2_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+hangup2_valid=$($hangup2_valid_ts && $hangup2_valid_py)
+
+# outbound
+echo ""; echo "Testing OUTBOUND Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "NEW_OUTBOUND_CALL"' >>basic-event.json
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+outbound_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+outbound_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+outbound_valid=$($outbound_valid_ts && $outbound_valid_py)
+
+# ringing
+echo ""; echo "Testing RINGING Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "RINGING"' >>basic-event.json
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+ringing_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+ringing_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+ringing_valid=$($ringing_valid_ts && $ringing_valid_py)
+
+# answered
+echo ""; echo "Testing CALL_ANSWERED Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "CALL_ANSWERED"' >>basic-event.json
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+answered_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+answered_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+answered_valid=$($answered_valid_ts && $answered_valid_py)
+
+# bad selector
+echo ""; echo "Testing IMBAAD Input"; echo ""; echo ""
+
+rm -f basic-event.json
+cat ../../../../events/inbound.json | jq '.InvocationEventType = "IMBAAD"' >>basic-event.json
+rm -f basic-out.json
+node ../../lambda-runner.js ./cases/basic/basic-event.json basic-out.json >/dev/null
+badsel_valid_ts=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+python3 ../../lambda-runner.py basic-event.json basic-out.json
+badsel_valid_py=$(ajv validate -s basic-schema.json -d basic-out.json >/dev/null && echo true || echo false)
+
+badsel_valid=$($badsel_valid_ts && $badset_valid_py)
+
+success=$($single_client_valid && $blank_valid && $success_valid && $hangup_valid && $hangup2_valid && $outbound_valid && $ringing_valid && $answered_valid && $badsel_valid)
+$success && echo "PASSES" || echo "FAILS"
+
+if [ -z $success ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/lambdas/call-and-bridge/src/test/cases/new-call/new-call-schema.json
+++ b/lambdas/call-and-bridge/src/test/cases/new-call/new-call-schema.json
@@ -1,0 +1,30 @@
+{
+    "required": [
+          "SchemaVersion",
+          "Actions"
+      ],
+      "properties": {
+          "SchemaVersion": {
+              "type": "string",
+              "const": "1.0"
+          },
+          "Actions": {
+              "type": "array",
+              "items": {
+                  "type": "object",
+                  "required": [
+                      "Type",
+                      "Parameters"
+                  ],
+                  "properties": {
+                      "Type": {
+                          "type": "string"
+                      },
+                      "Parameters": {
+                          "type": "object"
+                      }
+                  }
+              }
+          }
+      }
+  }

--- a/lambdas/call-and-bridge/src/test/cases/new-call/new-call.bash
+++ b/lambdas/call-and-bridge/src/test/cases/new-call/new-call.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# 
+
+echo ""; echo "Testing New Call Input"; echo ""; echo ""
+
+cp ../../../../events/inbound.json new-call-event.json
+
+rm -f new-call-out.json
+node ../../lambda-runner.js ./cases/new-call/new-call-event.json new-call-out.json >/dev/null
+validates_ts=$(ajv validate -s new-call-schema.json -d new-call-out.json >>/dev/null 2>>/dev/null && echo true || echo false)
+
+# validate content
+#  PAUSE
+has_pause_with_millis_ts=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="Pause") | .Parameters.DurationInMilliseconds != null')
+# PLAY
+has_play_with_audio_source_ts=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="PlayAudio") | .Parameters.AudioSource != null')
+# HANGUP
+has_hangup_resp_0_ts=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="Hangup") | .Parameters.SipResponseCode == "0"')
+
+# python
+python3 ../../lambda-runner.py new-call-event.json new-call-out-py.json
+validates_py=$(ajv validate -s new-call-schema.json -d new-call-out.json >>/dev/null 2>>/dev/null && echo true || echo false)
+
+#  PAUSE
+has_pause_with_millis_py=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="Pause") | .Parameters.DurationInMilliseconds != null')
+# PLAY
+has_play_with_audio_source_py=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="PlayAudio") | .Parameters.AudioSource != null')
+# HANGUP
+has_hangup_resp_0_py=$(cat new-call-out.json | jq '.Actions[] | select(.Type=="Hangup") | .Parameters.SipResponseCode == "0"')
+
+
+validates=$($validates_ts && $validates_py)
+has_pause_with_millis=$($has_pause_with_millis_ts && $has_pause_with_millis_py)
+has_play_with_audio_source=$(has_play_with_audio_source_ts && $has_play_with_audio_source_py)
+has_hangup_resp_0=$(has_hangup_resp_0_ts && $has_hangup_resp_0_py)
+
+success=$($validates && $has_pause_with_millis && $has_play_with_audio_source && $has_hangup_resp_0)
+$success && echo "PASSES" || echo "FAILS"
+
+if [ -z $success ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/lambdas/call-and-bridge/src/test/lambda-runner.py
+++ b/lambdas/call-and-bridge/src/test/lambda-runner.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# 
+
+import json
+import sys
+
+from index import handler
+
+event_file = sys.argv[1]
+out_file = sys.argv[2]
+
+with open(event_file) as f:
+    event = json.load(f)
+
+r = handler(event, None)
+
+with open(out_file, mode='w') as f:
+    s = json.dumps(r, indent=2)
+    f.write(s)

--- a/lambdas/call-lex-bot/src/.vscode/settings.json
+++ b/lambdas/call-lex-bot/src/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/lambdas/call-lex-bot/src/index.py
+++ b/lambdas/call-lex-bot/src/index.py
@@ -36,17 +36,6 @@ pause_action = {
     }
 }
 
-# play_audio_action = {
-#     'Type': "PlayAudio",
-#     'Parameters': {
-#         'Repeat': "1",
-#         'AudioSource': {
-#             'Type': "S3",
-#             'BucketName': wav_file_bucket,
-#             'Key': "",
-#         }
-#     }
-# }
 
 speak_action = {
   'Type': "Speak",

--- a/lambdas/call-lex-bot/src/package.json
+++ b/lambdas/call-lex-bot/src/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --coverage",
+    "test:py": "python3 -m unittest -v test/lambda_function_test.py",
     "test:prep-debug": "rm -f *.d.ts *.js"
   },
   "devDependencies": {

--- a/lambdas/call-make-recording/.vscode/settings.json
+++ b/lambdas/call-make-recording/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./src",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/lambdas/call-make-recording/src/.vscode/settings.json
+++ b/lambdas/call-make-recording/src/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/lambdas/call-make-recording/src/package.json
+++ b/lambdas/call-make-recording/src/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --coverage",
+    "test:py": "python3 -m unittest -v test/lambda_function_test.py",
     "test:prep-debug": "rm -f *.d.ts *.js"
   },
   "devDependencies": {

--- a/lambdas/call-me-back/src/.vscode/settings.json
+++ b/lambdas/call-me-back/src/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/lambdas/call-me-back/src/index.py
+++ b/lambdas/call-me-back/src/index.py
@@ -33,17 +33,6 @@ pause_action = {
     }
 }
 
-# play_audio_action = {
-#     'Type': "PlayAudio",
-#     'Parameters': {
-#         'Repeat': "1",
-#         'AudioSource': {
-#             'Type': "S3",
-#             'BucketName': wav_file_bucket,
-#             'Key': "",
-#         }
-#     }
-# }
 
 speak_action = {
   'Type': "Speak",

--- a/lambdas/call-me-back/src/package.json
+++ b/lambdas/call-me-back/src/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --coverage",
+    "test:py": "python3 -m unittest -v test/lambda_function_test.py",
     "test:prep-debug": "rm -f *.d.ts *.js"
   },
   "devDependencies": {

--- a/lambdas/call-play-recording/src/.vscode/settings.json
+++ b/lambdas/call-play-recording/src/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/lambdas/call-transcribe-recording/package.json
+++ b/lambdas/call-transcribe-recording/package.json
@@ -15,6 +15,7 @@
     "number": "scripts/number",
     "lambda": "scripts/lambda",
     "swap": "scripts/swap && scripts/active",
+    "swap:py": "scripts/swap-py && scripts/active",
     "active": "scripts/active && scripts/active",
     "versions": "scripts/versions",
     "invoke": "scripts/invoke",
@@ -22,6 +23,7 @@
     "logs": "scripts/logs"
   },
   "devDependencies": {
+    "@aws-cdk/aws-lambda-python-alpha": "^2.23.0-alpha.0",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "@types/source-map-support": "^0.5.4",
@@ -29,7 +31,7 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.4"
   },
   "dependencies": {
     "@aws-sdk/client-chime": "^3.52.0",
@@ -39,6 +41,7 @@
     "constructs": "^10.0.0",
     "esbuild": "^0.14.23",
     "path": "^0.12.7",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "typescript": "~4.6.4"
   }
 }

--- a/lambdas/call-transcribe-recording/scripts/active
+++ b/lambdas/call-transcribe-recording/scripts/active
@@ -5,14 +5,19 @@ ACTIVE=$(aws chime get-sip-media-application --sip-media-application-id  $SMA_ID
 
 PARENT=$(jq -r .[].smaHandlerArn $BASEDIR/cdk-outputs.json) 
 LOCAL=$(jq -r .[].smaHandlerArn ./cdk-outputs.json) 
+LOCAL_PY=$(jq -r '.[].pyHandlerArn' ./cdk-outputs.json) 
 DONE="There is an error, please check the lambda associations"
 
 P="PARENT is active:    $PARENT"
 L="LOCAL is active:     $LOCAL"
+PY="  *PYTHON* version"
 
 if [ $ACTIVE == $PARENT ]; then
   echo $P
-fi
-if [ $ACTIVE == $LOCAL ]; then
+elif [ $ACTIVE == $LOCAL ]; then
   echo $L
+elif [ $ACTIVE == $LOCAL_PY ]; then
+  echo $L; echo $PY
+else
+  echo $DONE
 fi

--- a/lambdas/call-transcribe-recording/scripts/clean
+++ b/lambdas/call-transcribe-recording/scripts/clean
@@ -7,4 +7,14 @@ rm -Rf package-lock.json yarn.lock
 rm -Rf src/*~ lib/*~ test/*~ userdata/*~ scripts/*~ configs/*~
 echo "removing node_modules, this takes a moment..."
 rm -Rf node_modules
+# remove testing cruft
+rm -f src/*.d.ts src/*.js
+rm -Rf src/coverage
+rm -Rf src/htmlcov
+rm -Rf src/node_modules
+mv src/test/lambda-runner.js src/test/lambda-runner.js.save
+rm src/test/*.d.ts src/test/*.js
+mv src/test/lambda-runner.js.save src/test/lambda-runner.js
+rm -Rf src/test/cases/**/*-event*.json
+rm -Rf src/test/cases/**/*-out*.json
 echo "all done!"

--- a/lambdas/call-transcribe-recording/scripts/swap-py
+++ b/lambdas/call-transcribe-recording/scripts/swap-py
@@ -1,0 +1,23 @@
+#!/bin/bash
+BASEDIR=../..
+SMA_ID=$(jq -r '.[].smaId' $BASEDIR/cdk-outputs.json)  # parent CDK folder
+ACTIVE=$(aws chime get-sip-media-application --sip-media-application-id  $SMA_ID | jq -r '.[].Endpoints[0].LambdaArn')
+echo "Active lambda is: $ACTIVE"
+
+PARENT=$(jq -r '.[].smaHandlerArn' $BASEDIR/cdk-outputs.json) 
+LOCAL=$(jq -r '.[].pyHandlerArn' ./cdk-outputs.json) 
+DONE="There is an error, please check the lambda associations"
+
+echo "PARENT lambda:    $PARENT"
+echo "LOCAL lambda:     $LOCAL"
+
+if [ $ACTIVE == $LOCAL ]; then
+  ENDPOINTS="[{\"LambdaArn\": \"$PARENT\"}]"
+  DONE="updating SMA $SMA_ID to use lambda $PARENT"
+  aws chime update-sip-media-application  --sip-media-application-id $SMA_ID --endpoints "$ENDPOINTS"
+else
+  ENDPOINTS="[{\"LambdaArn\": \"$LOCAL\"}]"
+  DONE="updating SMA $SMA_ID to use lambda $LOCAL"
+  aws chime update-sip-media-application  --sip-media-application-id $SMA_ID --endpoints "$ENDPOINTS"
+  echo $DONE
+fi

--- a/lambdas/call-transcribe-recording/src/.vscode/settings.json
+++ b/lambdas/call-transcribe-recording/src/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./test",
+        "-p",
+        "*_test.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "python.linting.pycodestyleEnabled": true,
+    "python.linting.enabled": true
+}

--- a/lambdas/call-transcribe-recording/src/index.py
+++ b/lambdas/call-transcribe-recording/src/index.py
@@ -1,0 +1,428 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import boto3
+from copy import deepcopy
+import json
+import logging
+import os
+
+
+# Set LogLevel using environment variable, fallback to INFO if not present
+logger = logging.getLogger()
+log_level = os.getenv('LogLevel', 'INFO')
+if log_level not in ['INFO', 'DEBUG']:
+    log_level = 'INFO'
+logger.setLevel(log_level)
+log_prefix = ''
+
+
+#
+# statics
+#
+wav_file_bucket = os.getenv('WAVFILE_BUCKET', None)
+
+transcribe_client = boto3.client('transcribe')
+s3_client = boto3.client('s3')
+
+
+
+# To read more on customizing the Pause action, see https://docs.aws.amazon.com/chime/latest/dg/pause.html
+def pause_action(call_id=None):
+    a = {
+        'Type': 'Pause',
+        'Parameters': {
+                # 'CallId': call_id,
+                'DurationInMilliseconds': '3000'
+        }
+    }
+    if call_id is not None:
+        a['Parameters']['CallId'] = call_id
+
+    return a
+
+
+def speak_action(speak_text):
+    return {
+        'Type': "Speak",
+        'Parameters': {
+            'Engine': "neural",         # Required. Either standard or neural
+            'LanguageCode': "en-US",    # Optional
+            'Text': speak_text,         # Required
+            'TextType': "ssml",         # Optional. Defaults to text
+            'VoiceId': "Matthew"        # Required
+        }
+    }
+
+
+def play_audio_action(key):
+    return {
+        'Type': "PlayAudio",
+        'Parameters': {
+            'Repeat': "1",
+            'AudioSource': {
+                'Type': "S3",
+                'BucketName': wav_file_bucket,
+                'Key': key,
+            },
+        },
+    }
+
+
+def record_audio_action(call_id, prefix):
+    return {
+        'Type': "RecordAudio",
+        'Parameters': {
+            'CallId': call_id,
+            'DurationInSeconds': "30",
+            'SilenceDurationInSeconds': 3,
+            'SilenceThreshold': 100,
+            'RecordingTerminators': ["#"],
+            'RecordingDestination': {
+                'Type': "S3",
+                'BucketName': wav_file_bucket,
+                'Prefix': prefix
+            }}}
+
+def transcribe_params(call_id, uri):
+    return {
+        'TranscriptionJobName': call_id,
+        'LanguageCode': "en-US",
+        'MediaFormat': "wav",
+        'Media': {
+            'MediaFileUri': uri,
+        },
+        'OutputBucketName': wav_file_bucket,
+        'OutputKey': f"{call_id}/{call_id}",
+    }
+
+def hangup_action():
+    return {
+        'Type': "Hangup",
+        'Parameters': {
+            'SipResponseCode': "0",
+            'ParticipantTag': "",
+  },
+}
+
+###
+
+
+def speak_and_get_digits_action(call_id, regex, speak_text):
+    return {
+        'Type': 'SpeakAndGetDigits',
+        'Parameters': {
+            'CallId': call_id,
+            'InputDigitsRegex': regex,
+            'SpeechParameters': {
+                'Text': speak_text,
+                'Engine': "neural",
+                'LanguageCode': "en-US",
+                'TextType': "ssml",
+                'VoiceId': "Joanna"
+            },
+            'FailureSpeechParameters': {
+                'Text': "<speak>Sorry, there was an error.</speak>",
+                'Engine': "neural",
+                'LanguageCode': "en-US",
+                'TextType': "ssml",
+                'VoiceId': "Joanna"
+            },
+            'MinNumberOfDigits': 11,
+            'MaxNumberOfDigits': 11,
+            'TerminatorDigits': ['#'],
+            'InBetweenDigitsDurationInMilliseconds': 5000,
+            'Repeat': 3,
+            'RepeatDurationInMilliseconds': 10000
+        }
+    }
+
+
+# To read more on customizing the VoiceFocus action, see https://docs.aws.amazon.com/chime/latest/dg/voicefocus.html
+def voicefocus_action(call_id, enabled=True):
+    return {
+        'Type': 'VoiceFocus',
+        "Parameters": {
+                'Enable': enabled,
+                'CallId': call_id,
+        }
+    }
+
+
+# To read more on customizing the ReceiveDigits action, see https://docs.aws.amazon.com/chime/latest/dg/listen-to-digits.html
+def receive_digits_action(call_id):
+    return {
+        'Type': 'ReceiveDigits',
+        'Parameters': {
+                'CallId': call_id,
+                'InputDigitsRegex': '[0-1]$',
+                'InBetweenDigitsDurationInMilliseconds': 1000,
+                'FlushDigitsDurationInMilliseconds': 10000
+        }
+    }
+
+
+# To read more on customizing the CallAndBridge action, see https://docs.aws.amazon.com/chime/latest/dg/call-and-bridge.html
+def call_and_bridge_action(caller_id, destination):
+    return {
+        'Type': 'CallAndBridge',
+        'Parameters': {
+            'CallTimeoutSeconds': 30,
+            'CallerIdNumber': caller_id,
+            'RingbackTone': {
+                'Type': "S3",
+                'BucketName': wav_file_bucket,
+                'Key': "ringback.wav"
+            },
+            'Endpoints':
+            [
+                {
+                    'Uri': destination,
+                    'BridgeEndpointType': 'PSTN'
+                }
+            ]
+        }
+    }
+
+
+# A wrapper for all responses back to the service
+def response(*actions):
+    return {
+        'SchemaVersion': '1.0',
+        'Actions': [*actions]
+    }
+
+#
+# handlers
+#
+
+
+# For new incoming calls, speak a greeting and collect digits of destination number.
+# Regex for digits entered allows US calling, except for premium rate numbers
+def new_call_handler(e):
+    resp = response(
+        pause_action(),
+        speak_action(
+            "<speak>Hello!  Please record a message after the tone, and press pound when you are done.</speak>")
+    )
+    resp['TransactionAttributes'] = {"state": "new"}
+
+    return resp
+
+
+def place_call(e):
+    call_id = e['CallDetails']['Participants'][0]['CallId']
+    from_number = e['CallDetails']['Participants'][0]['From']
+    received_digits = f"+{e['ActionData']['ReceivedDigits']}"
+
+    return [
+        pause_action(call_id),
+        call_and_bridge_action(from_number, received_digits)
+    ]
+
+
+def connect_call(e):
+    caller = list(filter(lambda p: p['Direction'] ==
+                  "Inbound", e['CallDetails']['Participants']))[0]
+    recipient = list(filter(
+        lambda p: p['Direction'] == "Outbound", e['CallDetails']['Participants']))[0]
+
+    return [voicefocus_action(caller['CallId'], False),
+            voicefocus_action(recipient['CallId'], False),
+            receive_digits_action(caller['CallId'])
+            ]
+
+###
+
+
+def beep_call(e):
+    resp = response(
+        pause_action(),
+        play_audio_action("500hz-beep.wav")
+    )
+    resp['TransactionAttributes'] = {'state': 'beeping'}
+
+    return resp
+
+
+def record_call(e):
+    call_id = e['CallDetails']['Participants'][0]['CallId']
+    resp = response(
+        record_audio_action(call_id, call_id)
+    )
+    resp['TransactionAttributes'] = {'state': 'recording'}
+
+    return resp
+
+
+def transcribe_recording(e):
+    s3_uri = f"s3://{e['ActionData']['RecordingDestination']['BucketName']}/{e['ActionData']['RecordingDestination']['Key']}"
+    call_id = e['CallDetails']['Participants'][0]['CallId']
+    params = transcribe_params(call_id, s3_uri)
+
+    try:
+        r = transcribe_client.start_transcription_job(**params)
+
+    except Exception as err:
+        logger.error('Exception with Action Handler. Error: ', exc_info=err)
+
+    resp = response(
+        speak_action("<speak>Transcribing recording, please wait.  This may take up to fifteen seconds.</speak>")
+    )
+    resp['TransactionAttributes'] = {'state': 'transcribing',
+                                     "params": params }
+
+    return resp
+
+
+def get_read_and_parse_json_object(bucket, key):
+    result = s3_client.get_object(Bucket=bucket, Key=key)
+    data = json.loads(result['Body'].read())
+
+    return data
+
+
+def playback_recording(e):
+    # WIP
+    resp = response(
+        speak_action("<speak>Sorry, we encountered an error transcribing your message</speak>")
+    )
+    resp['TransactionAttributes'] = {'state': 'playing'}
+
+    job_name = e['CallDetails']['TransactionAttributes']['params']['TranscriptionJobName']
+
+    result = {}
+    status = "QUEUED"
+    while (status not in ("FAILED","COMPLETED")):
+        try:
+            result = transcribe_client.get_transcription_job(TranscriptionJobName=job_name)
+            status = result['TranscriptionJob']['TranscriptionJobStatus']
+
+        except Exception as err:
+            logger.error('Exception with Action Handler. Error: ', exc_info=err)
+            status = 'FAILED'
+            break
+
+    if (status == 'FAILED'):
+        logger.error(f"transcribe FAILED: {result}")
+        return resp
+
+    logger.info(f"transcribe complete: {result}")
+
+    try:
+        bucket = e['CallDetails']['TransactionAttributes']['params']['OutputBucketName']
+        key = e['CallDetails']['TransactionAttributes']['params']['OutputKey']
+        data = get_read_and_parse_json_object(bucket, key)
+
+        resp = response(
+            speak_action(f"<speak>Your message says, {data['results']['transcripts'][0]['transcript']}</speak>")
+        )
+        resp['TransactionAttributes'] = {'state': 'playing'}
+
+    except Exception as err:
+        logger.error('Exception getting transcription. Error: ', exc_info=err)
+
+    return resp
+
+
+def end_call(e):
+    resp = response(
+        pause_action(),
+        speak_action("<speak>Thank you!  Goodbye!</speak>"),
+        hangup_action()
+    )
+    resp['TransactionAttributes'] = {'state': 'finishing'}
+
+    return resp
+
+
+# If we receive an ACTION_SUCCESSFUL event we can take further actions,
+# or default to responding with a NoOp (empty set of actions)
+action_handlers = {
+    'new': beep_call,
+    'beeping': record_call,
+    'recording': transcribe_recording,
+    'transcribing': playback_recording,
+    'playing': end_call
+}
+
+
+def action_succesful_handler(e):
+    resp = response()
+
+    try:
+        resp = action_handlers[e['CallDetails']
+                               ['TransactionAttributes']['state']](e)
+    except KeyError:
+        pass
+    except Exception as err:
+        logger.error('Exception with Action Handler. Error: ', exc_info=err)
+
+    return resp
+
+
+def digits_recevied_handler(e):
+    actions = []
+
+    try:
+        if (e['ActionData']['Type'] != 'ReceivedDigits'):
+            raise Exception('Action Type is not ReceivedDigits')
+
+        caller = list(filter(
+            lambda p: p['Direction'] == "Inbound", e['CallDetails']['Participants']))[0]
+        recipient = list(filter(
+            lambda p: p['Direction'] == "Outbound", e['CallDetails']['Participants']))[0]
+
+        disable = e['ActionData']['ReceivedDigits'] == "0"
+        enable = e['ActionData']['ReceivedDigits'] == "1"
+
+        if not(disable ^ enable):
+            raise Exception('digit not [0|1]')
+
+        actions = [
+            voicefocus_action(caller, (enable and not disable)),
+            voicefocus_action(recipient, (enable and not disable)),
+            receive_digits_action(caller)
+        ]
+
+    except Exception as err:
+        logger.error(f"Exception in digits received.", exc_info=err)
+
+    return response(*actions)
+
+
+# message - handler mapping table
+event_handlers = {
+    'NEW_INBOUND_CALL': new_call_handler,
+    'ACTION_SUCCESSFUL': action_succesful_handler,
+    # 'HANGUP': response()
+}
+
+
+def handler(event, context):
+    logger.info(f"called with {json.dumps(event, indent=2)}")
+
+    resp = response()
+    try:
+        resp = event_handlers[event['InvocationEventType']](event)
+    except KeyError:
+        pass
+    except Exception as e:
+        logger.error(f"exception in Event Handler:", exc_info=e)
+
+    logger.info(f"returning {json.dumps(resp, indent=2)}")
+    return resp

--- a/lambdas/call-transcribe-recording/src/index.ts
+++ b/lambdas/call-transcribe-recording/src/index.ts
@@ -16,9 +16,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-//import { ChimeClient, CreateSipMediaApplicationCallCommand } from "@aws-sdk/client-chime";
-//import { SecretValue } from "aws-cdk-lib";
-//import { Interface } from "readline";
+
 import 'source-map-support/register';
 import { TranscribeClient, StartTranscriptionJobCommand, GetTranscriptionJobCommand, CallAnalyticsJobStatus } from "@aws-sdk/client-transcribe";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
@@ -26,6 +24,7 @@ import { Stream } from 'stream'
 
 const transcribeClient = new TranscribeClient({});
 const wavFileBucket = process.env['WAVFILE_BUCKET'];
+
 
 let generalResponse: smaResponse = {
   SchemaVersion: '1.0',
@@ -163,10 +162,6 @@ async function playbackRecording(event: any) {
   }
   return [speakAction];
 }
-
-
-
-
 
 async function getTransaction(event: any) {
 

--- a/lambdas/call-transcribe-recording/src/jest.config.ts
+++ b/lambdas/call-transcribe-recording/src/jest.config.ts
@@ -1,0 +1,9 @@
+import type {Config} from '@jest/types';
+// Sync object
+const config: Config.InitialOptions = {
+  verbose: true,
+  transform: {
+    '^.+\.tsx?$': 'ts-jest',
+  },
+};
+export default config;

--- a/lambdas/call-transcribe-recording/src/package.json
+++ b/lambdas/call-transcribe-recording/src/package.json
@@ -2,11 +2,12 @@
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --coverage",
-    "test:py": "python3 -m unittest -v test/lambda_function_test.py",
+    "test:py": "python3 -m unittest -v test/call_transcribe_test.py",
     "test:prep-debug": "rm -f *.d.ts *.js"
   },
   "devDependencies": {
-    "@types/jest": "^27.5.0",
+    "@aws-sdk/client-polly": "^3.87.0",
+    "@types/jest": "^27.4.1",
     "jest": "27",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",

--- a/lambdas/call-transcribe-recording/src/requirements.txt
+++ b/lambdas/call-transcribe-recording/src/requirements.txt
@@ -1,0 +1,15 @@
+attrs==21.4.0
+boto3==1.22.9
+botocore==1.25.9
+coverage==6.3.2
+importlib-resources==5.7.1
+jmespath==1.0.0
+jsonschema==4.4.0
+marshmallow==3.15.0
+packaging==21.3
+pyparsing==3.0.8
+pyrsistent==0.18.1
+python-dateutil==2.8.2
+s3transfer==0.5.2
+urllib3==1.26.9
+zipp==3.8.0

--- a/lambdas/call-transcribe-recording/src/test/call-transcribe.test.ts
+++ b/lambdas/call-transcribe-recording/src/test/call-transcribe.test.ts
@@ -1,0 +1,562 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { doesNotReject } from "assert"
+import { AnyPrincipal } from "aws-cdk-lib/aws-iam"
+import { env } from 'process'
+import { PollyClient, SynthesizeSpeechCommand } from "@aws-sdk/client-polly";
+
+
+let transcribeConstructorCallCount = 0
+let startTranscriptionJobCommandCallCnt = 0
+let getTranscriptionJobCommandCallCnt = 0
+let s3ConstructorCallCount = 0
+
+// set validate manually as the call to polly is long and can muck up the tests
+let validateSpeakText = false
+
+let original_send:any = null
+let send_force_error = false
+let send_force_okay = true
+let forced_error_message = 'forced error'
+function my_send<InputType extends object,
+    OutputType extends object>(
+        command: object, //AWS.Command<AWS.ClientInput, InputType, AWS.ClientOutput, OutputType, AWS.SmithyResolvedConfiguration<AWS.HandlerOptions>>, 
+        options?: object //AWS.HandlerOptions
+        ): Promise<any> {
+
+    if (send_force_error) {
+        return new Promise((resolve, reject) => {
+            reject(forced_error_message)
+        })
+    } else if (send_force_okay) {
+        return new Promise((resolve) => {
+            resolve(0)
+        })
+    } else {
+        expect(original_send !== undefined)
+        return original_send(command, options)
+    }
+    return original_send(command, options)
+}
+
+jest.mock('@aws-sdk/client-transcribe', () => {
+    const original = jest.requireActual('@aws-sdk/client-transcribe')
+
+    return {
+        ...original,
+        TranscribeClient: jest.fn()
+            .mockImplementation((arg) => {
+                transcribeConstructorCallCount += 1
+
+                let a_client = new original.TranscribeClient(arg)
+                if (send_force_error || send_force_okay) {
+                    original_send = a_client.send
+                    a_client.send = my_send
+                }
+
+                return a_client
+        }),
+        StartTranscriptionJobCommand: jest.fn()
+            .mockImplementation((arg) => {
+                startTranscriptionJobCommandCallCnt += 1
+
+                let command = {
+                    "middlewareStack": {},
+                    "input": { ...arg }
+                }
+                return command
+        }),
+        GetTranscriptionJobCommand: jest.fn()
+            .mockImplementation((arg) => {
+                getTranscriptionJobCommandCallCnt += 1
+
+                let command = {
+                    "middlewareStack": {},
+                    "input": { ...arg }
+                }
+                return command
+        })        
+    }
+})
+
+jest.mock('@aws-sdk/client-s3', () => {
+    const original = jest.requireActual('@aws-sdk/client-s3')
+
+    return {
+        ...original,
+        S3Client: jest.fn()
+            .mockImplementation((arg) => {
+                console.log(arg)
+                s3ConstructorCallCount += 1
+
+                let a_client = new original.S3Client(arg)
+                return a_client
+        })
+    }
+})
+
+const region_to_use = process.env['AWS_DEFAULT_REGION'] || 'us-west-2'
+const polly = new PollyClient({ region: region_to_use })
+
+const WAVFILE_BUCKET_VAR = 'WAVFILE_BUCKET'
+const fakeBucket = 'fake-bucket'
+describe('call-transcribe', () => {
+    beforeEach(() => {
+        jest.resetModules()
+
+        transcribeConstructorCallCount = 0
+        s3ConstructorCallCount = 0
+        startTranscriptionJobCommandCallCnt = 0
+        getTranscriptionJobCommandCallCnt = 0
+
+        process.env[WAVFILE_BUCKET_VAR] = fakeBucket
+    })
+
+    let test_event = require("../../events/inbound.json")
+
+    const hangup_response = {
+        SchemaVersion:"1.0",
+        Actions:[
+            { Type: "Hangup",
+              Parameters:{
+                  SipResponseCode:"0",
+                  ParticipantTag:""
+    }}]}
+
+    function expect_schema_10(r: any) {
+        expect(r).toEqual(expect.objectContaining({'SchemaVersion':'1.0'}))
+    }
+
+    function expect_pause(r: any) {
+        let rp = r.Actions.filter((a:any) => a.Type === 'Pause')
+        expect(rp.len == 1)
+        expect(rp[0]).toHaveProperty('Parameters.DurationInMilliseconds')
+    }
+
+    function expect_hangup(r: any) {
+        let rp = r.Actions.filter((a:any) => a.Type === 'Hangup')
+        expect(rp.len == 1)
+        expect(rp[0]).toHaveProperty('Parameters.SipResponseCode')
+    }
+
+    function expect_play_audio(r: any, bucketName=fakeBucket) {
+        let rp = r.Actions.filter((a:any) => a.Type === 'PlayAudio')
+        expect(rp.len == 1)
+
+        expect(rp[0]).toHaveProperty('Parameters.AudioSource.Key')
+        expect(rp[0]).toHaveProperty('Parameters.AudioSource.Type')
+        expect(rp[0].Parameters.AudioSource.BucketName).toEqual(bucketName)
+    }
+
+    function expect_record_audio(r: any) {
+        let rp = r.Actions.filter((a:any) => a.Type === 'RecordAudio')
+        expect(rp.len == 1)
+
+        expect(rp[0]).toHaveProperty('Parameters.CallId')
+        expect(rp[0]).toHaveProperty('Parameters.DurationInSeconds')
+        expect(rp[0]).toHaveProperty('Parameters.SilenceDurationInSeconds')
+        expect(rp[0]).toHaveProperty('Parameters.SilenceThreshold')
+        expect(rp[0]).toHaveProperty('Parameters.RecordingTerminators')
+        expect(rp[0]).toHaveProperty('Parameters.RecordingDestination.Type')
+        if (process.env[WAVFILE_BUCKET_VAR] !== undefined)
+            expect(rp[0]).toHaveProperty('Parameters.RecordingDestination.BucketName')
+        expect(rp[0]).toHaveProperty('Parameters.RecordingDestination.Prefix')
+    }
+
+    async function expect_speak_action(r: any, done: any) {
+        let rs = r.Actions.filter((a:any) => a.Type === 'Speak')
+        expect(rs.len == 1)
+        expect(rs[0].Parameters).toHaveProperty('Engine')
+        expect(rs[0].Parameters).toHaveProperty('Text')
+        expect(rs[0].Parameters).toHaveProperty('VoiceId')
+
+        // early exit unless this global is set truthy
+        if (!validateSpeakText) {
+            done()
+            return
+        }
+
+        // validate the text
+        const input = {
+            ...rs[0].Parameters,
+            OutputFormat: 'mp3'
+        }
+        const command = new SynthesizeSpeechCommand(input)
+        await polly.send(command)
+            .then( (resp) => {
+                done()
+            }, (error) => {
+                done(error)
+        }) 
+
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        }
+
+    function expect_call_and_bridge(r: any) {
+        let rc = r.Actions.filter((a:any) => a.Type === 'CallAndBridge')
+        expect(rc.len == 1)
+        expect(rc[0].Parameters).toHaveProperty('CallerIdNumber')
+
+        rc[0].Parameters.Endpoints.forEach((e: any) => {
+            expect(e).toHaveProperty('Uri')
+            expect(e).toHaveProperty('BridgeEndpointType')
+        })
+    }
+
+    function expect_voice_focus_N(r: any) {
+        let rv = r.Actions.filter((a:any) => a.Type === 'VoiceFocus')
+        // there can be multiples of this action!
+        rv.forEach((v: any) => {
+            expect(v.Parameters).toHaveProperty('Enable')
+            expect(v.Parameters).toHaveProperty('CallId')
+        })
+    }
+
+    function expect_receive_digits(r: any) {
+        let rd = r.Actions.filter((a:any) => a.Type === 'ReceiveDigits')
+        expect(rd.len == 1)
+        expect(rd[0].Parameters).toHaveProperty('InputDigitsRegex')
+    }
+
+    function expect_transaction_attributes(r: any, attrs: any) {
+        expect(r.TransactionAttributes).toEqual(expect.objectContaining(attrs))
+    }
+
+test('empty event', done => {
+    let event = {}
+    require("../index").handler(event, null, (_: any, r: any) => {     
+        try {
+            expect_schema_10(r)
+            done()
+        } catch (e) {
+            console.log("FAILURE: ", e, " from ", r)
+            done(e)
+        }
+    })
+})
+
+
+test('intantiates Transcribe Client', done => {
+    expect(transcribeConstructorCallCount).toEqual(0)
+
+    require("../index").handler({}, null, (_: any, r: any) => {
+        expect(transcribeConstructorCallCount).toBeGreaterThanOrEqual(1)
+        done()
+    })
+})
+
+
+test('wavFileBucket from env var', done => {
+    expect(process.env[WAVFILE_BUCKET_VAR]).toEqual(fakeBucket)
+    process.env[WAVFILE_BUCKET_VAR] = 'a-test-bucket'
+
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "new"}
+    
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_play_audio(r, 'a-test-bucket')
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('new inbound call', done => {
+    let event = {...test_event}
+    event.InvocationEventType = "NEW_INBOUND_CALL"
+
+    let lam = require("../index")
+    lam.handler(event, null, (_: any, r: any) => {
+        try {
+            console.log(JSON.stringify(r))
+
+            expect_schema_10(r)
+            expect_pause(r)
+
+            expect_transaction_attributes(r, { "state": "new" })
+
+            expect_speak_action(r, done)
+            // done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('succcess new', done => {
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "new"}
+    
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            console.log(JSON.stringify(r))
+
+            expect_schema_10(r)
+            expect_pause(r)
+            expect_play_audio(r)
+
+            expect_transaction_attributes(r, { "state": "beeping" })
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+function expect_beeping(done: any) {
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "beeping"}
+    
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            console.log(JSON.stringify(r))
+
+            expect_schema_10(r)
+            expect_record_audio(r)
+
+            expect_transaction_attributes(r, { "state": "recording" })
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+}
+
+test('succcess beeping', done => {
+    expect_beeping(done)
+})
+
+test('success beeping no bucket', done => {
+    delete process.env[WAVFILE_BUCKET_VAR]
+    expect(process.env[WAVFILE_BUCKET_VAR]).toBeUndefined()
+
+    expect_beeping(done)
+})
+
+function expect_recording(done: any) {
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "recording"}
+    event.ActionData = { "RecordingDestination": {
+        "BucketName": "recording-bucket",
+        "Key": "recording-key"
+    }}
+    
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect(startTranscriptionJobCommandCallCnt).toBeGreaterThanOrEqual(1)
+            expect_schema_10(r)
+
+            expect_transaction_attributes(r, { "state": "transcribing" })
+            
+            expect_speak_action(r, done)
+            // done()       // done is delegated to the speak_action
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+}
+
+test('succcess recording send okay', done => {
+    send_force_error = false; send_force_okay = true
+    expect_recording(done)
+})
+
+test('succcess recording send err', done => {
+    send_force_error = true; send_force_okay = false
+    expect_recording(done)
+})
+
+test('succcess recording no wavFileBucket', done => {
+    delete process.env[WAVFILE_BUCKET_VAR]
+
+    send_force_error = false; send_force_okay = true
+    expect_recording(done)
+})
+
+function expect_transcribing(done: any) {
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "transcribing"}
+    
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect(getTranscriptionJobCommandCallCnt).toBeGreaterThanOrEqual(1)
+
+            expect_schema_10(r)
+            expect_transaction_attributes(r, { "state": "playing"})
+            
+            expect_speak_action(r, done)
+            // done()           // done is delegated to the speak_action
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+}
+
+test('succcess transcribing okay', done => {
+    send_force_error = false; send_force_okay = true;
+    expect_transcribing(done)
+})
+
+test('succcess transcribing err', done => {
+    send_force_error = true; send_force_okay = false;
+    expect_transcribing(done)
+})
+
+test('success playing', done =>{
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "playing"}
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_schema_10(r)
+            expect_transaction_attributes(r, { "state": "finishing" })
+            expect_pause(r)
+            expect_hangup(r)
+
+            expect_speak_action(r, done)
+            // done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('success finishing', done =>{
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "finishing"}
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_schema_10(r)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('success bad state', done =>{
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {"state": "bogus"}
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_schema_10(r)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('success empty state', done =>{
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_SUCCESSFUL"
+    event.CallDetails.TransactionAttributes = {}
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_schema_10(r)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('action failed', done => {
+    let event = {...test_event}
+    event.InvocationEventType = "ACTION_FAILED"
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            expect_schema_10(r)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('hangup', done => {
+    let event = {...test_event}
+    event.InvocationEventType = "HANGUP"
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            console.log(JSON.stringify(r))
+
+            expect_schema_10(r)
+            expect(r.Actions.length == 0)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+test('bad type', done => {
+    let event = {...test_event}
+    event.InvocationEventType = "IMBAAD"
+
+    require("../index").handler(event, null, (_: any, r: any) => {
+        try {
+            console.log(JSON.stringify(r))
+
+            expect_schema_10(r)
+            expect(r.Actions.length == 0)
+
+            done()
+        } catch (e) {
+            console.log("UNMATCHING RESPONSE: ", r, " TO ", event)
+            done(e)
+        } 
+    })
+})
+
+})

--- a/lambdas/call-transcribe-recording/src/test/call_transcribe_test.py
+++ b/lambdas/call-transcribe-recording/src/test/call_transcribe_test.py
@@ -1,0 +1,444 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+from array import array
+from ast import expr_context
+from cmath import exp
+from copy import deepcopy
+from itertools import cycle
+import json
+from jsonschema import validate
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+import boto3
+
+
+class Test_Transcribe(unittest.TestCase):
+    bucket_env_var = "WAVFILE_BUCKET"
+    fake_bucket_name = "fake-bucket"
+
+    def __init__(self, methodName: str = ...) -> None:
+        super().__init__(methodName)
+
+        with open("../../../events/inbound.json") as f:
+            self.test_event = json.load(f)
+
+        with open("./test/cases/basic/basic-schema.json") as f:
+            self.basic_schema = json.load(f)
+
+        with open("./test/cases/new-call/new-call-schema.json") as f:
+            self.new_call_schema = json.load(f)
+
+        # this is what would come back from a get_object / read()
+        self.canned_transcribe_result = b'{"jobName":"4623f486-0feb-476f-97e6-f60b56c4accf","accountId":"123","results":{"transcripts":[{"transcript":"This is a message to transcribe."}],"items":[{"start_time":"1.29","end_time":"1.56","alternatives":[{"confidence":"1.0","content":"This"}],"type":"pronunciation"},{"start_time":"1.56","end_time":"1.71","alternatives":[{"confidence":"1.0","content":"is"}],"type":"pronunciation"},{"start_time":"1.71","end_time":"1.83","alternatives":[{"confidence":"1.0","content":"a"}],"type":"pronunciation"},{"start_time":"1.83","end_time":"2.73","alternatives":[{"confidence":"1.0","content":"message"}],"type":"pronunciation"},{"start_time":"2.76","end_time":"2.82","alternatives":[{"confidence":"0.9094","content":"to"}],"type":"pronunciation"},{"start_time":"2.83","end_time":"3.96","alternatives":[{"confidence":"0.9975","content":"transcribe"}],"type":"pronunciation"},{"alternatives":[{"confidence":"0.0","content":"."}],"type":"punctuation"}]},"status":"COMPLETED"}'
+
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        # set env vars
+        os.environ[Test_Transcribe.bucket_env_var] = Test_Transcribe.fake_bucket_name
+
+    def tearDown(self) -> None:
+        # force an import the target function each and every time
+        if 'index' in sys.modules:
+            del sys.modules["index"]
+
+        # reset env vars
+        os.environ.pop(Test_Transcribe.bucket_env_var, None)
+
+        super().tearDown()
+
+    def check_validate(self, d, s):
+        try:
+            validate(instance=d, schema=s)
+            self.assertTrue(True)
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_schema_10(self, d):
+        self.check_validate(d, self.basic_schema)
+
+    def check_new_call_schema(self, d):
+        self.check_validate(d, self.new_call_schema)
+
+    def check_empty_actions(self, d):
+        try:
+            self.assertEqual(len(d['Actions']), 0)
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_pause(self, d, count=1):
+        rp = list(filter(lambda a: a['Type'] == 'Pause', d['Actions']))
+        self.assertEqual(len(rp), count)
+        try:
+            [self.assertIsNotNone(
+                r['Parameters']['DurationInMilliseconds']) for r in rp]
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_pause2(self, d):
+        self.check_pause(d, count=2)
+
+    def check_speak(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'Speak', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['Engine'])
+            self.assertIsNotNone(rp[0]['Parameters']['Text'])
+            self.assertIsNotNone(rp[0]['Parameters']['VoiceId'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_transaction_attrs(self, d, attrs):
+        try:
+            self.assertIsNotNone(d['TransactionAttributes'])
+            for k, v in attrs.items():
+                self.assertEquals(d['TransactionAttributes'][k], v)
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_record_audio(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'RecordAudio', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['CallId'])
+            self.assertIsNotNone(rp[0]['Parameters']['DurationInSeconds'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['SilenceDurationInSeconds'])
+            self.assertIsNotNone(rp[0]['Parameters']['SilenceThreshold'])
+            self.assertIsNotNone(rp[0]['Parameters']['RecordingTerminators'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['RecordingDestination']['Type'])
+
+            if (os.getenv(Test_Transcribe.bucket_env_var, None) is not None):
+                self.assertIsNotNone(
+                    rp[0]['Parameters']['RecordingDestination']['BucketName'])
+
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['RecordingDestination']['Prefix'])
+
+        except Exception as e:
+            self.assertTrue(False, e)
+
+
+    def check_speak_collect_digits(self, d) -> None:
+        rp = list(filter(lambda a: a['Type'] ==
+                  'SpeakAndGetDigits', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['CallId'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['SpeechParameters']['Text'])
+            self.assertIsNotNone(rp[0]['Parameters']
+                                 ['FailureSpeechParameters']['Text'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_call_and_bridge(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'CallAndBridge', d['Actions']))
+        self.assertEqual(len(rp), 1)
+
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['CallerIdNumber'])
+
+            for e in rp[0]['Parameters']['Endpoints']:
+                self.assertIsNotNone(e['Uri'])
+                self.assertIsNotNone(e['BridgeEndpointType'])
+
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_voice_focus(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'VoiceFocus', d['Actions']))
+        self.assertGreaterEqual(len(rp), 1)
+
+        try:
+            for v in rp:
+                self.assertIsNotNone(v['Parameters']['Enable'])
+                self.assertIsNotNone(v['Parameters']['CallId'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_receive_digits(self, d) -> None:
+        rp = list(filter(
+            lambda a: a['Type'] == 'ReceiveDigits', d['Actions']))
+        self.assertEqual(len(rp), 1)
+
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['InputDigitsRegex'])
+        except Exception as e:
+            self.assertTrue(False, e)
+
+    def check_play(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'PlayAudio', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertIsNotNone(rp[0]['Parameters']['AudioSource'])
+        except Exception as e:
+            self.assertTrue(False, e.message)
+
+    def check_hangup(self, d):
+        rp = list(filter(lambda a: a['Type'] == 'Hangup', d['Actions']))
+        self.assertEqual(len(rp), 1)
+        try:
+            self.assertEqual(rp[0]['Parameters']['SipResponseCode'], '0')
+        except Exception as e:
+            self.assertTrue(False, e.message)
+
+    def call_and_test(self, event, tests: array):
+        # since the static setup is tested separately, need to reload
+        from index import handler
+
+        r = handler(event, None)
+        [t(r) for t in tests]
+
+    def copy_caller_to_recipient(self, event):
+        participant = deepcopy(event['CallDetails']['Participants'][0])
+        participant['Direction'] = "Outbound"
+        event['CallDetails']['Participants'].append(participant)
+
+    #
+    # Tests
+    #
+
+    def test_empty(self):
+        event = {}
+        self.call_and_test(event, [self.check_schema_10])
+
+
+    def test_wav_file_bucket_env_var(self):
+        # unset any env var for the bucket
+        import index
+        # .setUp() sets an env var
+        self.assertEqual(index.wav_file_bucket,
+                         Test_Transcribe.fake_bucket_name)
+
+        # # reset it all...
+        self.tearDown()
+        self.assertIsNone(os.getenv(Test_Transcribe.bucket_env_var, None))
+
+        import index
+        self.assertIsNone(index.wav_file_bucket)
+
+    def test_log_level_set_from_env_var(self):
+        import index
+        self.assertEqual(index.log_level, 'INFO')
+
+        self.tearDown()
+        os.environ['LogLevel'] = 'DEBUG'
+        import index
+        self.assertEqual(index.log_level, 'DEBUG')
+
+    def test_new_inbound_call(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "NEW_INBOUND_CALL"
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_pause,
+                            self.check_speak,
+                            lambda r: self.check_transaction_attrs(
+                                r, {"state": "new"})
+                            ])
+
+    def test_action_successful_new(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "new"}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_pause,
+                            self.check_play,
+                            lambda r: self.check_transaction_attrs(
+                                r, {"state": "beeping"})
+                            ])
+
+    def test_action_successful_beeping(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "beeping"}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_record_audio,
+                            lambda r: self.check_transaction_attrs(
+                                r, {"state": "recording"})
+                            ])
+
+    def test_action_successful_beeping_no_bucket(self):
+        os.environ.pop(Test_Transcribe.bucket_env_var, None)
+
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "beeping"}
+
+        self.call_and_test(event,
+                           [self.check_schema_10,
+                            self.check_record_audio,
+                            lambda r: self.check_transaction_attrs(
+                                r, {"state": "recording"})
+                            ])
+
+    def test_action_successful_recording_okay(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "recording"}
+        event['ActionData'] = {"RecordingDestination": {
+            "BucketName": "recording-bucket",
+            "Key": "recording-key"
+        }}
+
+        import index as lam
+        with patch.object(lam.transcribe_client, 'start_transcription_job') as job_starter: 
+            job_starter.return_value={}
+
+            r = lam.handler(event, None)
+            
+            self.check_speak(r)
+            self.check_transaction_attrs(r, {"state": "transcribing"})
+
+
+    def test_action_successful_recording_err(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "recording"}
+        event['ActionData'] = {"RecordingDestination": {
+            "BucketName": "recording-bucket",
+            "Key": "recording-key"
+        }}
+
+        import index as lam
+        with patch.object(lam.transcribe_client, 'start_transcription_job') as job_starter: 
+            job_starter.side_effect = Exception('Boom!')
+
+            r = lam.handler(event, None)
+            
+            self.check_speak(r)
+            self.check_transaction_attrs(r, {"state": "transcribing"})
+
+
+    status_cnt = -1
+    def cycle_status(**kwargs):
+        status = ['QUEUED','IN_PROGRESS', 'FAILED', 'COMPLETED']
+
+        Test_Transcribe.status_cnt = (Test_Transcribe.status_cnt + 1) % len(status)
+        return { 'TranscriptionJob': {
+                    'TranscriptionJobStatus': status[Test_Transcribe.status_cnt]
+        }}
+
+    def test_action_successful_transcribing(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {
+            "state": "transcribing",
+            "params": {'TranscriptionJobName': 'job-name',
+            # sample test settings... can be substituted with others, or completely faked
+            "OutputBucketName": "calltranscriberecordingstack-wavfiles98e3397d-1xm2sgmjz2hjl",
+            "OutputKey": "4623f486-0feb-476f-97e6-f60b56c4accf/4623f486-0feb-476f-97e6-f60b56c4accf.json"
+        }}
+
+        import index as lam
+        with patch.object(lam.transcribe_client, 'get_transcription_job') as job_status: 
+            job_status.return_value = {
+                'TranscriptionJob': {
+                    'TranscriptionJobStatus': 'COMPLETED'
+                }}
+
+            r = lam.handler(event, None)
+
+            self.check_speak(r)
+            self.check_transaction_attrs(r, {"state": "playing"})
+
+    def test_action_successful_transcribing_err(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {
+            "state": "transcribing",
+            "params": {'TranscriptionJobName': 'job-name'}}
+
+        import index as lam
+        orig = lam.transcribe_client.get_transcription_job
+        try:
+            lam.transcribe_client.get_transcription_job = Test_Transcribe.cycle_status
+
+            r = lam.handler(event, None)
+            
+            self.check_speak(r)
+            self.check_transaction_attrs(r, {"state": "playing"})
+
+        except Exception as err:
+            pass
+
+        finally:
+            lam.transcribe_client.get_transcription_job = orig
+
+    def test_action_successful_playing(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "playing"}
+
+        self.call_and_test(event,
+                    [self.check_schema_10,
+                    self.check_pause,
+                    self.check_speak,
+                    self.check_hangup,
+                    lambda r: self.check_transaction_attrs(r, {"state": "finishing"})])
+
+
+    def test_action_successful_finishing(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "finishing"}
+
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_action_successful_bad_state(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "bogus"}
+
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_action_successful_empty_state(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_SUCCESSFUL"
+        event['CallDetails']['TransactionAttributes'] = {"state": "bogus"}
+
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_action_failed(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "ACTION_FAILED"
+
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_hangup(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "HANGUP"
+        self.call_and_test(event, [self.check_schema_10])
+
+    def test_bad_action(self):
+        event = deepcopy(self.test_event)
+        event['InvocationEventType'] = "IMBAAD"
+        self.call_and_test(event, [self.check_schema_10])

--- a/lambdas/call-transcribe-recording/src/test/cases/basic/basic-schema.json
+++ b/lambdas/call-transcribe-recording/src/test/cases/basic/basic-schema.json
@@ -1,0 +1,12 @@
+{
+    "required": [
+          "SchemaVersion",
+          "Actions"
+      ],
+  "properties": {
+          "SchemaVersion": {
+              "type": "string",
+              "const": "1.0"
+          }
+      }
+  }

--- a/lambdas/call-transcribe-recording/src/test/cases/new-call/new-call-schema.json
+++ b/lambdas/call-transcribe-recording/src/test/cases/new-call/new-call-schema.json
@@ -1,0 +1,30 @@
+{
+    "required": [
+          "SchemaVersion",
+          "Actions"
+      ],
+      "properties": {
+          "SchemaVersion": {
+              "type": "string",
+              "const": "1.0"
+          },
+          "Actions": {
+              "type": "array",
+              "items": {
+                  "type": "object",
+                  "required": [
+                      "Type",
+                      "Parameters"
+                  ],
+                  "properties": {
+                      "Type": {
+                          "type": "string"
+                      },
+                      "Parameters": {
+                          "type": "object"
+                      }
+                  }
+              }
+          }
+      }
+  }

--- a/lambdas/call-transcribe-recording/tsconfig.json
+++ b/lambdas/call-transcribe-recording/tsconfig.json
@@ -25,6 +25,7 @@
     ]
   },
   "exclude": [
+    "src/test",
     "node_modules",
     "cdk.out"
   ]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "aws-cdk-lib": "2.12.0",
@@ -36,6 +36,7 @@
     "esbuild": "^0.14.23",
     "source-map-support": "^0.5.16",
     "stream": "^0.0.2",
+    "typescript": "^4.6.4",
     "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
feat: all lambdas now available as either Python or TypeScript. CDK stack deploys both functions and swap scripts allow switching between them. Full unit test suites included for both TypeScript and Python.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
